### PR TITLE
Do not assume "ordinary text without R code" in output

### DIFF
--- a/tests/testthat/test-autonewsmd.R
+++ b/tests/testthat/test-autonewsmd.R
@@ -97,7 +97,7 @@ test_that("correct functioning of autonewsmd", {
   out <- capture_output_lines({
     an$write(con = f)
   })
-  expect_output(cat(out), regexp = "ordinary text without R code")
+  expect_true(length(out) > 0)
   close(f) # close the file
 
   # no


### PR DESCRIPTION
The next version of knitr will no longer print out this message: https://yihui.org/en/2023/01/knitr-progress-bar/

Thanks!