### PR TITLE
fix: "compare"-url generation now has a dash/hyphen in it

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -51,18 +51,10 @@ jobs:
           r-version: ${{ matrix.config.r }}
           Ncpus: 4
 
-      # LaTeX. Installation time:
-      # Linux: ~ 1 min
-      # macOS: ~ 1 min 30s
-      # Windows: never finishes
-      - uses: r-lib/actions/setup-tinytex@v2
+      - uses: quarto-dev/quarto-actions/setup@v2
         if: matrix.config.latex == 'true'
-        env:
-          # install full prebuilt version
-          TINYTEX_INSTALLER: TinyTeX
-
-      - uses: r-lib/actions/setup-pandoc@v2
-        if: matrix.config.latex == 'true'
+        with:
+          tinytex: true
 
       - uses: actions/setup-java@v1
         if: matrix.config.java == 'true'

--- a/.github/workflows/tic.yml
+++ b/.github/workflows/tic.yml
@@ -45,14 +45,10 @@ jobs:
           r-version: ${{ matrix.config.r }}
           Ncpus: 4
 
-      - uses: r-lib/actions/setup-tinytex@v2
+      - uses: quarto-dev/quarto-actions/setup@v2
         if: matrix.config.latex == 'true'
-        env:
-          # install full prebuilt version
-          TINYTEX_INSTALLER: TinyTeX
-
-      - uses: r-lib/actions/setup-pandoc@v2
-        if: matrix.config.latex == 'true'
+        with:
+          tinytex: true
 
       - uses: actions/setup-java@v1
         if: matrix.config.java == 'true'
@@ -78,7 +74,7 @@ jobs:
       - name: "[Stage] Configure R Java"
         if: runner.os != 'Windows' && matrix.config.java == 'true'
         run: "echo export PATH=$PATH > reconf.sh; echo export JAVA_HOME=$JAVA_HOME >> reconf.sh; echo R CMD javareconf >> reconf.sh; sudo bash reconf.sh"
-        
+
       - name: "[Stage] Install pak"
         run: Rscript -e "install.packages('pak', repos = 'https://r-lib.github.io/p/pak/stable')"
 

--- a/.github/workflows/tic.yml
+++ b/.github/workflows/tic.yml
@@ -45,6 +45,9 @@ jobs:
           r-version: ${{ matrix.config.r }}
           Ncpus: 4
 
+      - uses: r-lib/actions/setup-pandoc@v2
+        if: runner.os == 'macOS'
+
       - uses: quarto-dev/quarto-actions/setup@v2
         if: matrix.config.latex == 'true'
         with:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,8 +16,8 @@ Imports:
     data.table,
     git2r,
     magrittr,
+    quarto,
     R6,
-    rmarkdown,
     utils
 Suggests: 
     knitr,
@@ -25,6 +25,6 @@ Suggests:
     testthat (>= 3.0.1)
 VignetteBuilder: 
     knitr
-Date/Publication: 2023-08-29 17:45:50.167713 UTC
+Date/Publication: 2023-08-29 18:22:46.178717 UTC
 Encoding: UTF-8
 RoxygenNote: 7.2.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: autonewsmd
 Title: Auto-Generate Changelog using Conventional Commits
-Version: 0.0.6.9001
+Version: 0.0.6.9002
 Authors@R: 
     person("Lorenz A.", "Kapsner", , "lorenz.kapsner@gmail.com", role = c("cre", "aut", "cph"),
            comment = c(ORCID = "0000-0003-1866-860X"))
@@ -25,6 +25,6 @@ Suggests:
     testthat (>= 3.0.1)
 VignetteBuilder: 
     knitr
-Date/Publication: 2023-08-29 18:22:46.178717 UTC
+Date/Publication: 2023-08-30 06:49:26.101959 UTC
 Encoding: UTF-8
 RoxygenNote: 7.2.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: autonewsmd
 Title: Auto-Generate Changelog using Conventional Commits
-Version: 0.0.6
+Version: 0.0.6.9001
 Authors@R: 
     person("Lorenz A.", "Kapsner", , "lorenz.kapsner@gmail.com", role = c("cre", "aut", "cph"),
            comment = c(ORCID = "0000-0003-1866-860X"))
@@ -25,6 +25,6 @@ Suggests:
     testthat (>= 3.0.1)
 VignetteBuilder: 
     knitr
-Date/Publication: 2023-04-13 15:26:10 UTC
+Date/Publication: 2023-08-29 17:45:50.167713 UTC
 Encoding: UTF-8
 RoxygenNote: 7.2.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 
 #### Bug fixes
 
+-   moving from rmarkdown to quarto for rendering news.md
+    ([80a8fca](https://github.com/kapsner/autonewsmd/tree/80a8fcaa4b2397e9db29b70cabd4902a3ac47604))
 -   addresses issue with gitlab comparison found by @joundso
     ([c5ae722](https://github.com/kapsner/autonewsmd/tree/c5ae7220459f6ca73daeafa72fa27e341125189c))
 -   “compare”-url generation now has a slash in it
@@ -18,7 +20,7 @@
     ([a5f4da2](https://github.com/kapsner/autonewsmd/tree/a5f4da2cc998e36ee5dfd4fa7635ec9d0364067e))
 
 Full set of changes:
-[`v0.0.6...c5ae722`](https://github.com/kapsner/autonewsmd/compare/v0.0.6...c5ae722)
+[`v0.0.6...80a8fca`](https://github.com/kapsner/autonewsmd/compare/v0.0.6...80a8fca)
 
 ## v0.0.6 (2023-04-13)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,12 @@
 
 # autonewsmd NEWS
 
-## Unreleased (2023-08-29)
+## Unreleased (2023-08-30)
 
 #### Bug fixes
 
+-   fixed issue with presence of multiple associated remote repos
+    ([341960a](https://github.com/kapsner/autonewsmd/tree/341960a531c04d2058112f3be77213d76b917915))
 -   moving from rmarkdown to quarto for rendering news.md
     ([80a8fca](https://github.com/kapsner/autonewsmd/tree/80a8fcaa4b2397e9db29b70cabd4902a3ac47604))
 -   addresses issue with gitlab comparison found by @joundso
@@ -12,15 +14,24 @@
 -   “compare”-url generation now has a slash in it
     ([b7afdc1](https://github.com/kapsner/autonewsmd/tree/b7afdc1f640754e0f24e2f5372818758da3956a8))
 
+#### CI
+
+-   re-introduced pandoc installation for macos runners
+    ([54b022b](https://github.com/kapsner/autonewsmd/tree/54b022be62defe118f307fcbeead00efdf1485f2))
+-   added quarto installation to gha
+    ([11adf80](https://github.com/kapsner/autonewsmd/tree/11adf8057a1ebae1a1965bf50da9a563432267f2))
+
 #### Other changes
 
+-   added message to indicate location of copied output file
+    ([1ce501a](https://github.com/kapsner/autonewsmd/tree/1ce501a70ee2527690fbde553f4c467779ecbc96))
 -   updated description
     ([77dc1d9](https://github.com/kapsner/autonewsmd/tree/77dc1d9d64b821d036e50f0c565c9c9abf91bf4e))
 -   updated news.md to v0.0.6
     ([a5f4da2](https://github.com/kapsner/autonewsmd/tree/a5f4da2cc998e36ee5dfd4fa7635ec9d0364067e))
 
 Full set of changes:
-[`v0.0.6...80a8fca`](https://github.com/kapsner/autonewsmd/compare/v0.0.6...80a8fca)
+[`v0.0.6...54b022b`](https://github.com/kapsner/autonewsmd/compare/v0.0.6...54b022b)
 
 ## v0.0.6 (2023-04-13)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,12 @@
+
 # autonewsmd NEWS
 
 ## Unreleased (2023-08-29)
 
 #### Bug fixes
 
+-   addresses issue with gitlab comparison found by @joundso
+    ([c5ae722](https://github.com/kapsner/autonewsmd/tree/c5ae7220459f6ca73daeafa72fa27e341125189c))
 -   “compare”-url generation now has a slash in it
     ([b7afdc1](https://github.com/kapsner/autonewsmd/tree/b7afdc1f640754e0f24e2f5372818758da3956a8))
 
@@ -15,7 +18,7 @@
     ([a5f4da2](https://github.com/kapsner/autonewsmd/tree/a5f4da2cc998e36ee5dfd4fa7635ec9d0364067e))
 
 Full set of changes:
-[`v0.0.6...b7afdc1`](https://github.com/kapsner/autonewsmd/compare/v0.0.6...b7afdc1)
+[`v0.0.6...c5ae722`](https://github.com/kapsner/autonewsmd/compare/v0.0.6...c5ae722)
 
 ## v0.0.6 (2023-04-13)
 
@@ -43,7 +46,7 @@ Full set of changes:
     ([a9211ea](https://github.com/kapsner/autonewsmd/tree/a9211ea4994e5d53aff9989f43afbb33a094a094))
 -   added mlsurvlrnrs pkg to used by section
     ([3d5a012](https://github.com/kapsner/autonewsmd/tree/3d5a012643fd6bedb54e23ffd870d6447cadbb63))
--   merge pull request \#5 from kapsner/development
+-   merge pull request #5 from kapsner/development
     ([3b07f0a](https://github.com/kapsner/autonewsmd/tree/3b07f0afe953e11194b81fcf0ada306dee191bb3))
 -   updated news.md
     ([5decf24](https://github.com/kapsner/autonewsmd/tree/5decf248ec4b12bcdc54baeedf631075657fad5a))
@@ -66,7 +69,7 @@ Full set of changes:
 
 -   fixed issue when only one commit available
     ([1c323d1](https://github.com/kapsner/autonewsmd/tree/1c323d115274b09fe9e05695ed95a89084a3cd6a))
--   fixed reference to type\_mappings in private
+-   fixed reference to type_mappings in private
     ([65ece46](https://github.com/kapsner/autonewsmd/tree/65ece468574594c8377e2db2d621a490af6979cd))
 
 #### Refactorings

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,22 @@
 # autonewsmd NEWS
 
+## Unreleased (2023-08-29)
+
+#### Bug fixes
+
+-   “compare”-url generation now has a slash in it
+    ([b7afdc1](https://github.com/kapsner/autonewsmd/tree/b7afdc1f640754e0f24e2f5372818758da3956a8))
+
+#### Other changes
+
+-   updated description
+    ([77dc1d9](https://github.com/kapsner/autonewsmd/tree/77dc1d9d64b821d036e50f0c565c9c9abf91bf4e))
+-   updated news.md to v0.0.6
+    ([a5f4da2](https://github.com/kapsner/autonewsmd/tree/a5f4da2cc998e36ee5dfd4fa7635ec9d0364067e))
+
+Full set of changes:
+[`v0.0.6...b7afdc1`](https://github.com/kapsner/autonewsmd/compare/v0.0.6...b7afdc1)
+
 ## v0.0.6 (2023-04-13)
 
 #### Other changes

--- a/R/generate_autonewsmd.R
+++ b/R/generate_autonewsmd.R
@@ -186,8 +186,15 @@ generate_autonewsmd <- function(self, private) {
       )
       append_list[["full_changes"]] <- paste0(
         "Full set of changes:\ [`", set_changes,
-        "`](", file.path(repo_url, "-", "compare", set_changes), ")"
+        "`](", file.path(repo_url, "compare", set_changes, fsep = "/"), ")"
       )
+      if (grepl(pattern = "^(http(s)?://)?.*gitlab.*\\/", x = repo_url)) {
+        append_list[["full_changes"]] <- gsub(
+          pattern = "\\/compare\\/",
+          replacement = "/-/compare/",
+          x = append_list[["full_changes"]]
+        )
+      }
     }
     repo_list[[tn]] <- append_list
   }

--- a/R/generate_autonewsmd.R
+++ b/R/generate_autonewsmd.R
@@ -186,7 +186,7 @@ generate_autonewsmd <- function(self, private) {
       )
       append_list[["full_changes"]] <- paste0(
         "Full set of changes:\ [`", set_changes,
-        "`](", file.path(repo_url, "compare", set_changes), ")"
+        "`](", file.path(repo_url, "-", "compare", set_changes), ")"
       )
     }
     repo_list[[tn]] <- append_list

--- a/R/init_autonewsmd.R
+++ b/R/init_autonewsmd.R
@@ -42,9 +42,33 @@ init_autonewsmd <- function(self, private, repo_name, repo_path, repo_remotes) {
     repo = private$repo,
     remote = repo_remotes
   )
-  private$repo_url <- gsub(
+  repo_url <- gsub(
     pattern = "\\.git$",
     replacement = "",
     x = repo_url
   )
+  ru_len <- length(repo_url)
+  if (ru_len > 1) {
+    msg <- paste0(
+      "More than one associated remote repositories detected.\n",
+      "Which one should be used for generating the NEWS.md file?\n\n"
+    )
+    msg_repos <- paste0(seq_along(repo_url), ") ", repo_url, "\n")
+    msg <- paste0(
+      msg, paste0(msg_repos, collapse = "")
+    )
+    message(msg)
+    valid_choice <- FALSE
+    while (!valid_choice) {
+      choice <- readline(prompt = "Please enter the desired repository: ")
+      if (!is.integer(as.integer(choice)) || (as.integer(choice) < 1) ||
+          (as.integer(choice) > ru_len)) {
+        message(paste0("\nPlease enter an integer between 1 and ", ru_len))
+      } else {
+        repo_url <- repo_url[as.integer(choice)]
+        valid_choice <- TRUE
+      }
+    }
+  }
+  private$repo_url <- repo_url
 }

--- a/R/mdtemplate_tags_decreasing.R
+++ b/R/mdtemplate_tags_decreasing.R
@@ -32,7 +32,8 @@ mdtemplate_tags_decreasing <- function(repo_list, change_hierarchy, repo_url) {
           cat(paste0(
             "- ", chg_commits[chg_row, get("clean_summary")], " ([",
             chg_commits[chg_row, get("sha_seven")], "](",
-            file.path(repo_url, "tree", chg_commits[chg_row, get("sha")]), "))"
+            file.path(repo_url, "tree", chg_commits[chg_row, get("sha")],
+                      fsep = "/"), "))"
           ), "\n")
         }
       }

--- a/R/prepare_rda.R
+++ b/R/prepare_rda.R
@@ -1,0 +1,33 @@
+# Auto-Generate Changelog using Conventional Commits
+# Copyright (C) 2022 Lorenz A. Kapsner
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+prepare_rda <- function(self, private) {
+
+  stopifnot(
+    "`repo_list` is missing or `NULL`" = !is.null(self$repo_list),
+    "`repo_url` is missing or `NULL`" = !is.null(private$repo_url)
+  )
+
+  repo_list <- self$repo_list
+  repo_url <- private$repo_url
+  repo_name <- self$repo_name
+  file_name <- self$file_name
+
+  save(
+    repo_list, repo_name, repo_url, file_name, mdtemplate_tags_decreasing,
+    file = file.path(tempdir(), "autonewsmd.Rda")
+  )
+}

--- a/R/write_autonewsmd.R
+++ b/R/write_autonewsmd.R
@@ -113,6 +113,9 @@ write_autonewsmd <- function(self, private, force, con) {
     to = outfile,
     overwrite = TRUE
   )
+  message(paste0(
+    "Copied generated '", I(paste0(file_name, file_ending)),
+    "' to '", outfile, "'."))
 
   invisible(file.remove(template_file))
   invisible(file.remove(md_temp_file))

--- a/README.md
+++ b/README.md
@@ -152,4 +152,3 @@ newsmd
 - add options to format the changelog
 - add more changelog style templates
 - add support for [Commit message with scope](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope)
-- switch rendering of md to quarto -> challenges: currently, quarto does not allow to pass objects from the environment to the document that is rendered; hence, one needs to find a solution how to pass the `repo_list`, which is created in the `get_git_log` function (as well as some other objects) on to the *.qmd file for properly rendering the document.

--- a/data-raw/devstuffs.R
+++ b/data-raw/devstuffs.R
@@ -54,7 +54,7 @@ usethis::use_package("R", min_version = "3.4", type = "Depends")
 usethis::use_package("data.table", type = "Imports")
 usethis::use_package("magrittr", type = "Imports")
 usethis::use_package("git2r", type = "Imports")
-usethis::use_package("rmarkdown", type = "Imports")
+usethis::use_package("quarto", type = "Imports")
 usethis::use_package("R6", type = "Imports")
 usethis::use_package("utils", type = "Imports")
 

--- a/data-raw/devstuffs.R
+++ b/data-raw/devstuffs.R
@@ -19,7 +19,7 @@ my_desc$set_authors(c(
 # Remove some author fields
 my_desc$del("Maintainer")
 # Set the version
-my_desc$set_version("0.0.6.9001")
+my_desc$set_version("0.0.6.9002")
 # The title of your package
 my_desc$set(Title = "Auto-Generate Changelog using Conventional Commits")
 # The description of your package

--- a/data-raw/devstuffs.R
+++ b/data-raw/devstuffs.R
@@ -19,7 +19,7 @@ my_desc$set_authors(c(
 # Remove some author fields
 my_desc$del("Maintainer")
 # Set the version
-my_desc$set_version("0.0.6")
+my_desc$set_version("0.0.6.9001")
 # The title of your package
 my_desc$set(Title = "Auto-Generate Changelog using Conventional Commits")
 # The description of your package

--- a/inst/templates/news-md-template.qmd
+++ b/inst/templates/news-md-template.qmd
@@ -18,6 +18,7 @@ change_hierarchy <- c(
   "Style",
   "Other changes"
 )
+load("./autonewsmd.Rda")
 ```
 
 # `r repo_name` `r file_name`

--- a/vignettes/autonewsmd.Rmd
+++ b/vignettes/autonewsmd.Rmd
@@ -130,7 +130,7 @@ Executing the `$write()`-method, the changelog is written to the path specified 
 
 ```{r writenmd}
 an$write(force = TRUE)
-#> processing file: autonewsmd-5272f03178-news-md-template.Rmd
+#> processing file: autonewsmd-5272f03178-news-md-template.qmd
 #> output file: autonewsmd-5272f03178-news-md-template.knit.md
 #> /usr/lib/rstudio-server/bin/quarto/bin/tools/pandoc +RTS -K512m -RTS autonewsmd-5272f03178-news-md-template.knit.md --to markdown_strict-yaml_metadata_block --from markdown+autolink_bare_uris+tex_math_single_backslash --output /tmp/RtmpY9K0uU/autonewsmd/NEWS.md
 #> 
@@ -174,7 +174,7 @@ git2r::commit(repo, "chore: added news.md file")
 #> [07b6c39] 2022-09-02: chore: added news.md file
 an$generate()
 an$write(force = TRUE)
-#> processing file: autonewsmd-52215e4b2b-news-md-template.Rmd
+#> processing file: autonewsmd-52215e4b2b-news-md-template.qmd
 #> output file: autonewsmd-52215e4b2b-news-md-template.knit.md
 #> /usr/lib/rstudio-server/bin/quarto/bin/tools/pandoc +RTS -K512m -RTS autonewsmd-52215e4b2b-news-md-template.knit.md --to markdown_strict-yaml_metadata_block --from markdown+autolink_bare_uris+tex_math_single_backslash --output /tmp/RtmpY9K0uU/autonewsmd/NEWS.md
 #> 


### PR DESCRIPTION
Hi @kapsner,
the compare-URLs seem to have slightly changed:
https://gitlab.miracum.org/miracum/misc/diztools/-/commit/e950968000fcc98d8e809eb558ab8075466f0f93#8e91c39ea457744ee86e8378b154b7f3bb28e325_86_89

I stumbled across this when I wanted to upload a new CRAN release with the automatically created news.md and CRAN rejected due to the "moved url".